### PR TITLE
depext: Fix the yum command for repository update (instead of package upgrade)

### DIFF
--- a/src/client/opamDepextCommand.ml
+++ b/src/client/opamDepextCommand.ml
@@ -58,7 +58,7 @@ let update_command = match family with
   | "homebrew" ->
     ["brew"; "update"]
   | "rhel" | "centos" | "fedora" | "mageia" | "oraclelinux" ->
-    ["yum"; "-y"; "update"]
+    ["yum"; "makecache"]
   | "archlinux" | "arch" ->
     ["pacman"; "-S"]
   | "gentoo" ->


### PR DESCRIPTION
`yum update` is the equivalent of `apt-get upgrade` not `apt-get update`. `yum makecache` is the right command to use